### PR TITLE
add null to Constraint['value'] type union

### DIFF
--- a/src/services/validator.ts
+++ b/src/services/validator.ts
@@ -174,6 +174,17 @@ export class Validator {
       };
     }
 
+    if (constraint.value === null && !["==", "!=", "contains", "not contains"].includes(constraint.operator)) {
+      return {
+        isValid: false,
+        error: {
+          message:
+            '"operator" must be in ["==", "!=", "contains", "not contains"] if "value" is null.',
+          element: constraint,
+        },
+      };
+    }
+
     // We must check that the value is an array if the operator is 'in' or 'not in'.
     if (
       ["in", "not in", "contains any", "not contains any"].includes(

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -26,7 +26,8 @@ export interface Constraint {
     | number
     | boolean
     | Record<string, unknown>
-    | (string | number | boolean | Record<string, unknown>)[];
+    | (string | number | boolean | Record<string, unknown>)[]
+    | null;
 }
 
 export interface Condition<R = any> {

--- a/test/engine.spec.ts
+++ b/test/engine.spec.ts
@@ -9,6 +9,7 @@ import { subRulesValid1Json } from "./rulesets/sub-rules-valid1.json";
 import { subRulesValid2Json } from "./rulesets/sub-rules-valid2.json";
 
 import { Operator, RulePilot, RuleError } from "../src";
+import { valid10Json } from "./rulesets/valid10.json";
 
 describe("RulePilot engine correctly", () => {
   it("Evaluates a simple ruleset", async () => {
@@ -305,4 +306,15 @@ describe("RulePilot engine correctly", () => {
       })
     ).toEqual(12);
   });
+
+  it("Evaluates a rule with null values correctly", async () => {
+    expect(await RulePilot.evaluate(valid10Json, {
+      foo: null,
+      bar: "test",
+      foo_array: ["test", null],
+      bar_array: ["test"],
+    })).toEqual(true);
+  });
+
+  
 });

--- a/test/rulesets/invalid3.json.ts
+++ b/test/rulesets/invalid3.json.ts
@@ -1,0 +1,28 @@
+// an invalid rule with null and greater than
+import { Rule } from "../../src";
+
+export const invalid3Json: Rule = {
+  conditions: [
+    {
+      any: [
+        {
+          field: "foo",
+          operator: ">=",
+          value: null,
+        },
+      ],
+      result: 3,
+    },
+    {
+      all: [
+        {
+          field: "Category",
+          operator: "==",
+          value: "Islamic",
+        },
+      ],
+      result: 4,
+    },
+  ],
+  default: 2,
+};

--- a/test/rulesets/valid10.json.ts
+++ b/test/rulesets/valid10.json.ts
@@ -1,0 +1,30 @@
+import { Rule } from "../../src";
+
+export const valid10Json: Rule = {
+  conditions: [
+    {
+      all: [
+        {
+          field: "foo",
+          operator: "==",
+          value: null,
+        },
+        {
+          field: "bar",
+          operator: "!=",
+          value: null,
+        },
+        {
+          field: "foo_array",
+          operator: "contains",
+          value: null,
+        },
+        {
+          field: "bar_array",
+          operator: "not contains",
+          value: null,
+        },
+      ],
+    }
+  ],
+};

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -2,8 +2,10 @@ import { valid1Json } from "./rulesets/valid1.json";
 import { valid3Json } from "./rulesets/valid3.json";
 import { invalid1Json } from "./rulesets/invalid1.json";
 import { subRulesValid1Json } from "./rulesets/sub-rules-valid1.json";
+import { valid10Json } from "./rulesets/valid10.json";
 
 import { Operator, RulePilot, Condition, Constraint } from "../src";
+import { invalid3Json } from "./rulesets/invalid3.json";
 
 describe("RulePilot validator correctly", () => {
   it("Identifies a bad operator", () => {
@@ -94,7 +96,7 @@ describe("RulePilot validator correctly", () => {
     const validation = RulePilot.validate(invalid1Json);
 
     expect(validation.isValid).toEqual(false);
-    expect(validation.error.message).toEqual(
+    expect(validation.error?.message).toEqual(
       "Each node should be a condition or a constraint."
     );
   });
@@ -103,7 +105,7 @@ describe("RulePilot validator correctly", () => {
     const validation = RulePilot.validate({ conditions: [] });
 
     expect(validation.isValid).toEqual(false);
-    expect(validation.error.message).toEqual(
+    expect(validation.error?.message).toEqual(
       "The conditions property must contain at least one condition."
     );
   });
@@ -154,5 +156,11 @@ describe("RulePilot validator correctly", () => {
 
   it("Validates a rule with sub rules correctly", async () => {
     expect(RulePilot.validate(subRulesValid1Json).isValid).toEqual(true);
+  });
+  it("Validates a rule with null values correctly - valid", async () => {
+    expect(RulePilot.validate(valid10Json).isValid).toEqual(true);
+  });
+  it("Validates a rule with null values correctly - invalid", async () => {
+    expect(RulePilot.validate(invalid3Json).isValid).toEqual(false);
   });
 });


### PR DESCRIPTION
I've noticed that `null` isn't available as one of the types, even though it's a perfectly acceptable json type. This PR tries to include it in a simple way. I've run the lint process and it seems to work fine, and although I worry a small change like this may break other implementations of this library that assume any value coming from conditions are not nullish, I have to imagine other implementations must also be trying to handle null values..

I've written a couple of small basic tests. Any thoughts / guidance you can provide?